### PR TITLE
Vector2をstructに変更、BlazeFaceのatan2計算を修正

### DIFF
--- a/ailia-csharp/ailia-csharp/ailia/AiliaMigration.cs
+++ b/ailia-csharp/ailia-csharp/ailia/AiliaMigration.cs
@@ -42,7 +42,7 @@ namespace UnityEngine
         public byte b;
     }
 
-    public class Vector2
+    public struct Vector2
     {
         public float x;
         public float y;

--- a/ailia-csharp/ailia-csharp/facemesh/AiliaFaceMesh.cs
+++ b/ailia-csharp/ailia-csharp/facemesh/AiliaFaceMesh.cs
@@ -42,8 +42,8 @@ namespace ailiaSDK
 				int fy = (int)(face.center.y * tex_height);
 				const int RIGHT_EYE=0;
 				const int LEFT_EYE=1;
-				float theta_x = (float)(face.keypoints[LEFT_EYE].x - face.keypoints[RIGHT_EYE].x);
-				float theta_y = (float)(face.keypoints[LEFT_EYE].y - face.keypoints[RIGHT_EYE].y);
+				float theta_x = (float)(face.keypoints[LEFT_EYE].x - face.keypoints[RIGHT_EYE].x) * tex_width;
+				float theta_y = (float)(face.keypoints[LEFT_EYE].y - face.keypoints[RIGHT_EYE].y) * tex_height;
 				float theta = (float)System.Math.Atan2(theta_y,theta_x);
 
 				//extract data


### PR DESCRIPTION
Vector2をUnityに合わせてclassからstructに変更しました。
https://docs.unity3d.com/ja/2021.1/ScriptReference/Vector2.html
BlazeFaceのatan2でアスペクトを考慮できていない問題を修正しました。
https://github.com/axinc-ai/ailia-models-unity/pull/128